### PR TITLE
Important bug fix

### DIFF
--- a/alpha/Config.java
+++ b/alpha/Config.java
@@ -13,12 +13,12 @@ import util.Util;
 
 
 public class Config {
-	public static String VERSIONA = "0";
-	public static String VERSIONB = "7";
-	public static String VERSIONC = "7";
+	public static final String VERSIONA = "0";
+	public static final String VERSIONB = "7";
+	public static final String VERSIONC = "7";
 	public static String comment = "";
-	public static int BUILD = Integer.parseInt(VERSIONA)*100 + Integer.parseInt(VERSIONB)*10 + Integer.parseInt(VERSIONC);
-	public static String VERSION = VERSIONA+"."+VERSIONB+"."+VERSIONC+" "+comment;
+	public static final String BUILD = VERSIONA+ "."+ VERSIONB + "." + VERSIONC;
+	public static final String VERSION = BUILD +" "+ comment;
 	public static String BASE_DIR = "";
 	public static String CONFIG_DIR = "";
 	public static String DOWNLOAD_DIR = "";

--- a/alpha/Update.java
+++ b/alpha/Update.java
@@ -12,9 +12,6 @@ import java.util.Scanner;
 
 public class Update {
 	
-	public static String its(int i) {
-	    return Integer.toString(i);
-	}
 	public static String loadUpdate(String remote_bl_URL) {
 		// Don't load if no url was specified
 		if ((remote_bl_URL == null)||(remote_bl_URL == "")) {
@@ -87,7 +84,7 @@ public class Update {
 			 */
 			Logger.log(Logger.INFO, "loadUpdate",
 					"Processing updatefile");
-			int outversion = 0;
+			String outversion = null;
 	        String outtyp = null;
             String[] b;
 			while (s.hasNextLine()) {
@@ -98,7 +95,7 @@ public class Update {
 				b=l.split("!");
 				if (b.length == 5)
 				{
-				outversion = Integer.parseInt(b[1])*100 + Integer.parseInt(b[2])*10 + Integer.parseInt(b[3]);	
+				outversion = b[1] +"."+ b[2] +"."+ b[3];    	
 				}}
 				
 				if(l.startsWith("<typ!"))
@@ -119,10 +116,11 @@ public class Update {
 			// Close socket
 			ourSock.close();
 			
-			if(outversion!=0 & outtyp!=null)
+			if(outversion != null & outtyp!=null)
 			{
-			Logger.log(Logger.INFO, "loadUpdate","compare: " + its(Config.BUILD)+" with "+its(outversion));
-			if(Config.BUILD < outversion)
+			Logger.log(Logger.INFO, "loadUpdate","compare: " + Config.BUILD +" with "+ outversion);
+			
+			if(isOutdated(Config.BUILD, outversion))
 			{
 				return language.langtext[52]+outtyp;
 	
@@ -151,4 +149,36 @@ public class Update {
 
 	}
 
+	private static boolean isOutdated(String buildVersion, String outVersion) {
+		boolean isOutdated = false;
+		String[] buildVersionComponents = buildVersion.split("[.]");
+		String[] outVersionComponents = outVersion.split("[.]");
+
+		int buildVersionIndex = 0;
+		int outVersionIndex = 0;
+
+
+		while (buildVersionIndex < buildVersionComponents.length || outVersionIndex < outVersionComponents.length) {
+			final int currBuildVersionComponent = (buildVersionIndex < buildVersionComponents.length) ? 
+				Integer.parseInt(buildVersionComponents[buildVersionIndex]) : 0;
+
+			final int outBuildVersionComponent = (outVersionIndex < outVersionComponents.length) ?
+				Integer.parseInt(outVersionComponents[outVersionIndex]) : 0;
+			
+			if (currBuildVersionComponent < outBuildVersionComponent) {
+				isOutdated = true;
+				break;
+			} else if (currBuildVersionComponent > outBuildVersionComponent) {
+				// result is false
+				break;
+			}
+			
+			buildVersionIndex++;
+			outVersionIndex++;
+		}
+		
+
+		return isOutdated;
+	}
 }
+//

--- a/fileTransfer/FileReceiver.java
+++ b/fileTransfer/FileReceiver.java
@@ -58,7 +58,7 @@ public class FileReceiver implements IFileTransfer {
 		this.fileSize = fileSize;
 		this.nextStart = 0;
 		this.wrongBlockNumberCount = 0;
-		FileTransfer.receivers.put(buddy.getAddress() + " " + this.id, this);
+		FileTransfer.getReceivers().put(buddy.getAddress() + " " + this.id, this);
 		
 		this.gui = new GUITransfer(this, buddy, fileName, false);
 		gui.setVisible(true);
@@ -356,7 +356,7 @@ public void closethis() { // in pytorchat the equivelant is closeForced
 		//		new File(this.fileNameTmp).renameTo(new File(this.fileNameSave));
 		//		Logger.oldOut.println("Renamed " + this.fileNameTmp + " to " + this.fileNameSave);
 		//	}
-			FileTransfer.receivers.remove(buddy.getAddress() + " " + this.id);
+			FileTransfer.getReceivers().remove(buddy.getAddress() + " " + this.id);
 		} catch (IOException ioe) {
 			ioe.printStackTrace();
 		}

--- a/fileTransfer/FileSender.java
+++ b/fileTransfer/FileSender.java
@@ -67,7 +67,7 @@ public class FileSender implements Runnable, IFileTransfer {
 			this.fileSize = file.length(); // this.file_handle.tell();
 			this.gui.update(this.fileSize, 0);
 			// filename_utf8 = this.file_name_short.encode("utf-8"); FIXME ?
-			FileTransfer.senders.put(buddy.getAddress() + " " + this.id, this);
+			FileTransfer.getSenders().put(buddy.getAddress() + " " + this.id, this);
 
 			// if not this.buddy.isFullyConnected():
 			if (buddy.isFullyConnected()) {
@@ -320,7 +320,7 @@ public class FileSender implements Runnable, IFileTransfer {
 			}
 		}
 		// remove refference
-		FileTransfer.senders.remove(buddy.getAddress() + " " + this.id);
+		FileTransfer.getSenders().remove(buddy.getAddress() + " " + this.id);
 		// del this.buddy.bl.file_sender[this.buddy.address, this.id]
 	}
 	


### PR DESCRIPTION
Fixing wrong comparison of versions in Update. For instance, the two following versions would be (incorrectly) treated as equal: 1.15.12 and 2.6.2. Now, they're compared element by element. We're also free to compare versions of different lengths, like: 1.0 and 1.0.7.
